### PR TITLE
merge right command syntax (and code cleaning)

### DIFF
--- a/wp-cli-test-command.php
+++ b/wp-cli-test-command.php
@@ -89,16 +89,16 @@ class Theme_Test_Cmd extends WP_CLI_Command{
 	 * @param array $assoc_args  Incoming args associative array
 	 */
 	private function maybe_reinstall( $assoc_args ){
-		# does we have mandatory info?
-		if (
-			isset( $assoc_args['url'] ) &&
-			isset( $assoc_args['title'] ) &&
-			isset( $assoc_args['admin_name'] ) &&
-			isset( $assoc_args['admin_email'] ) &&
-			isset( $assoc_args['admin_password'] )
-		):
-			# if asked, reset database and install WP
-			if ( isset( $assoc_args['reset'] ) ):
+		# if asked, reset database and install WP
+		if ( isset( $assoc_args['reset'] ) ):
+			# does we have mandatory info?
+			if (
+				isset( $assoc_args['url'] ) &&
+				isset( $assoc_args['title'] ) &&
+				isset( $assoc_args['admin_name'] ) &&
+				isset( $assoc_args['admin_email'] ) &&
+				isset( $assoc_args['admin_password'] )
+			):
 				WP_CLI::launch( 'wp db reset' );
 				WP_CLI::launch(
 				'wp core install '
@@ -109,12 +109,12 @@ class Theme_Test_Cmd extends WP_CLI_Command{
 				.' --admin_password='.$assoc_args['admin_password']
 				);
 			else :
-				# check if WP is installed, or install it
-				WP_CLI::launch( 'wp core is-installed' );
-			endif;
-		else :
-
 			WP_CLI::error( 'Usage: wp theme-test install [--data=<data>] [--menus] [--reset] [--url=<url>] [--title=<title>] [--admin_name=<admin_name>] [--admin_email=<admin_email>] [--admin_password=<admin_password>]' );
+			endif;
+
+		else :
+			# check if WP is installed, or install it
+			WP_CLI::launch( 'wp core is-installed' );
 		endif;
 	}
 

--- a/wp-cli-test-command.php
+++ b/wp-cli-test-command.php
@@ -99,7 +99,7 @@ class Unit_Test_Cmd extends WP_CLI_Command{
 		):
 			# WordPress reset/reinstall
 			if ( isset( $assoc_args['reset'] ) ):
-				WP_CLI::launch( 'wp db reset --yes' );
+				WP_CLI::launch( 'wp db reset' );
 				WP_CLI::launch(
 				'wp core install '
 				.' --url='.$assoc_args['url']

--- a/wp-cli-test-command.php
+++ b/wp-cli-test-command.php
@@ -114,7 +114,7 @@ class Theme_Test_Cmd extends WP_CLI_Command{
 			endif;
 		else :
 
-			WP_CLI::error( 'Usage: wp theme-test setup --reset --url= --title= --admin_name= --admin_email= --admin_password=' );
+			WP_CLI::error( 'Usage: wp theme-test install [--data=<data>] [--menus] [--reset] [--url=<url>] [--title=<title>] [--admin_name=<admin_name>] [--admin_email=<admin_email>] [--admin_password=<admin_password>]' );
 		endif;
 	}
 
@@ -178,7 +178,7 @@ class Theme_Test_Cmd extends WP_CLI_Command{
 	* --menus 								Create custom nav menus (full page list, short random page list)
 	* 
 	* @when after_wp_load
-	* @synopsis [--data=<data>] [--url=<url>] [--title=<title>] [--admin_name=<admin_name>] [--admin_email=<admin_email>] [--admin_password=<admin_password>] [--menus] [--reset] [--dbname] [--dbuser] [--dbpass]
+	* @synopsis [--data=<data>] [--menus] [--reset] [--url=<url>] [--title=<title>] [--admin_name=<admin_name>] [--admin_email=<admin_email>] [--admin_password=<admin_password>]
 	*/
 	public function install( $args = null, $assoc_args = array() ){
 

--- a/wp-cli-test-command.php
+++ b/wp-cli-test-command.php
@@ -99,7 +99,7 @@ class Theme_Test_Cmd extends WP_CLI_Command{
 		):
 			# if asked, reset database and install WP
 			if ( isset( $assoc_args['reset'] ) ):
-				WP_CLI::launch( 'wp db reset' );			
+				WP_CLI::launch( 'wp db reset' );
 				WP_CLI::launch(
 				'wp core install '
 				.' --url='.$assoc_args['url']

--- a/wp-cli-test-command.php
+++ b/wp-cli-test-command.php
@@ -178,7 +178,7 @@ class Theme_Test_Cmd extends WP_CLI_Command{
 	* --menus 								Create custom nav menus (full page list, short random page list)
 	* 
 	* @when after_wp_load
-	* @synopsis [<slug>] [--data=<data>] [--url=<url>] [--title=<title>] [--admin_name=<admin_name>] [--admin_email=<admin_email>] [--admin_password=<admin_password>] [--menus] [--reset] [--dbname] [--dbuser] [--dbpass]
+	* @synopsis [--data=<data>] [--url=<url>] [--title=<title>] [--admin_name=<admin_name>] [--admin_email=<admin_email>] [--admin_password=<admin_password>] [--menus] [--reset] [--dbname] [--dbuser] [--dbpass]
 	*/
 	public function install( $args = null, $assoc_args = array() ){
 


### PR DESCRIPTION
- removed plugins/core wrapper options
- command renamed 'theme-test'
- minimal cmd with no options allowed: `wp theme-test install`
- will ask confirmation before database reset

Related: [wp-cli#147](https://github.com/wp-cli/wp-cli/issues/147#issuecomment-20533468)
