### PR TITLE
Can depend on WP-CLI 0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,4 @@
 {
-  "minimum-stability": "dev",
   "name": "pixline/wp-cli-theme-test-command",
   "type": "command",
   "description": "Install and configure WordPress theme unit tests",
@@ -16,7 +15,7 @@
   ],
   "require": {
         "php": ">=5.3.0",
-        "wp-cli/wp-cli": "dev-master"
+        "wp-cli/wp-cli": ">=0.11"
   },
   "support": {
     "issues": "https://github.com/pixline/wp-cli-theme-test-command/issues",


### PR DESCRIPTION
Since WP-CLI 0.11 has been released, you don't need to use dev-master anymore.
