### PR TITLE
Remove wp-cli/wp-cli dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.3.0"
   },
   "support": {
     "issues": "https://github.com/pixline/wp-cli-theme-test-command/issues",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
   ],
   "require": {
         "php": ">=5.3.0",
-        "wp-cli/wp-cli": ">=0.11"
   },
   "support": {
     "issues": "https://github.com/pixline/wp-cli-theme-test-command/issues",


### PR DESCRIPTION
Causes fatal error when used with `wp-cli.phar`: https://github.com/wp-cli/wp-cli/issues/1116
