### PR TITLE
Add instructions for installing via wp-cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ composer config repositories.wp-cli composer http://wp-cli.org/package-index/
 composer require pixline/wp-cli-theme-test-command=dev-master
 ```
 
+### Alternate install: WP-CLI package install
+
+1) Navigate to the WordPress root folder.
+
+2) Install the package using a wp-cli command.
+```bash
+wp package install pixline/wp-cli-theme-test-command
+```
 
 ## Usage
 


### PR DESCRIPTION
I tried the original install instructions for this but got an error. Using wp-cli package was way more straightforward—I figured other people might find it helpful as well.
