### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "pixline/wp-cli-theme-test-command",
-  "type": "command",
+  "type": "wp-cli-package",
   "description": "Install and configure WordPress theme unit tests",
   "keywords": ["wp-cli","theme-test"],
   "homepage": "https://github.com/pixline/wp-cli-theme-test-command",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
